### PR TITLE
Rewrite the about page as prose, with current resume content

### DIFF
--- a/app/assets/data/work-experience.ts
+++ b/app/assets/data/work-experience.ts
@@ -1,159 +1,79 @@
 interface WorkExperienceItem {
-  /** The title of the position */
-  position: string;
   /** The company name */
   company: string;
+  /** Roles held at the company, most recent first */
+  roles: string[];
   /** Start date */
   startDate: string;
   /** End date */
   endDate?: string;
-  /** List items for the description */
-  description: string[];
+  /** Prose describing the work, one entry per paragraph */
+  body: string[];
 }
 
 const en: WorkExperienceItem[] = [
   {
-    position: 'Design Engineer',
     company: 'Volume7',
+    roles: ['Design Engineer'],
     startDate: 'July 2026',
-    description: [
-      'Work across design and frontend development, moving between Figma and production code on the same client projects',
-      'Shipped frontend improvements to a live client product, resolving interaction defects and modernizing legacy UI',
-      'Building new B2B credit limit review features, carrying flows from design through implementation',
-      'Led discussions on how the team organizes design and development work as the org scales, covering handoff process and shared conventions',
+    body: [
+      'I work across design and frontend development, moving between Figma and production code on the same client projects. Building the thing I designed changes how I design the next one, so I try to stay on both sides of that line.',
+      "So far I've shipped frontend improvements to a live client product, fixing interaction defects and modernizing older UI, and I'm building new B2B credit limit review features from the first designs through to implementation. The team is growing, so I've also been helping work out how we organize design and development, including how work gets handed off and which conventions we hold in common.",
     ],
   },
   {
-    position: 'UX Engineer',
     company: 'Keatext',
+    roles: ['UX Engineer'],
     startDate: 'May 2021',
     endDate: 'May 2026',
-    description: [
-      'Owned product design and frontend direction for an AI analytics platform, serving as the bridge between design and engineering across the full product lifecycle',
-      'Designed and shipped the interface for an agentic analysis product, including an LLM-driven report with custom data visualization and a conversational interface for interrogating results',
-      'Redesigned the core experience for conversational AI where traditional UI patterns broke down, defining interaction models for streaming, uncertainty, and agent-initiated actions',
-      'Converted a fragmented UI into a reusable component system built on design tokens, then maintained it as production React and TypeScript with accessibility and interaction fidelity as requirements, not polish',
-      'Built token export and import tooling against the Figma API before the platform supported variables natively, keeping design and code in sync from a single source',
-      'Established design-to-development workflows with product owners and engineers that cut handoff loops and made design decisions legible in code',
+    body: [
+      "For five years I owned product design and frontend direction for an AI analytics platform, sitting between design and engineering for the whole product lifecycle. The work I liked most was the interface for an agentic analysis product: an LLM-generated report with custom data visualization, plus a conversational interface for digging into the results. Traditional UI patterns don't hold up well in conversational AI, so a lot of the job was working out interaction models for things like streaming output, uncertain answers, and actions the agent takes on its own.",
+      'The rest of the job was systems work. I turned a fragmented UI into a reusable component system built on design tokens, then maintained it as production React and TypeScript, with accessibility and interaction fidelity treated as requirements rather than finishing touches. Figma had no support for variables yet, so I built token export and import tooling against its API to keep design and code working from one source. I also set up design to development workflows with product owners and engineers, which cut down handoff loops and made design decisions easier to follow in code.',
     ],
   },
   {
-    position: 'UX/UI Design Lead',
     company: 'Spartan Bioscience',
-    startDate: 'June 2017',
-    endDate: 'May 2021',
-    description: [
-      'Built a design system from scratch, components, documentation, and Storybook, for medical device software in a regulated environment',
-      'Designed and built high-fidelity prototypes and production interfaces for diagnostic software and training products',
-      'Contributed design documentation to FDA 510(k) submissions and shipped HIPAA-compliant product surfaces',
-      'Developed and maintained a customer support portal and corporate site with headless CMS integration',
-      'Worked directly with engineering, management, and executive leadership to move design decisions forward',
-    ],
-  },
-  {
-    position: 'Marketing Coordinator',
-    company: 'Spartan Bioscience',
+    roles: ['UX/UI Design Lead', 'Marketing Coordinator'],
     startDate: 'April 2015',
-    endDate: 'June 2017',
-    description: [
-      'Contributed to UX and product design alongside the core team',
-      'Managed the company WordPress site and server infrastructure',
+    endDate: 'May 2021',
+    body: [
+      'I was at Spartan for six years, starting in marketing and moving into design. As Marketing Coordinator I worked on UX and product design with the core team while looking after the company WordPress site and its server infrastructure. I took over design in 2017.',
+      'After that I built a design system from scratch for medical device software in a regulated environment, covering components, documentation, and Storybook. I designed and built high fidelity prototypes and production interfaces for diagnostic software and training products. Because the environment was regulated, my design documentation fed into FDA 510(k) submissions and anything I shipped had to be HIPAA compliant. I also built and maintained a customer support portal and the corporate site on a headless CMS, working directly with engineering, management, and executive leadership.',
     ],
   },
 ];
 
 const fr: WorkExperienceItem[] = [
   {
-    position: 'Design Engineer',
     company: 'Volume7',
+    roles: ['Design Engineer'],
     startDate: 'juillet 2026',
-    description: [
-      'Travail à la fois en design et en développement front-end, en passant de Figma au code de production sur les mêmes projets clients',
-      "Livraison d'améliorations front-end sur un produit client en production, en corrigeant des défauts d'interaction et en modernisant une interface existante",
-      "Développement de nouvelles fonctionnalités B2B de révision des limites de crédit, du design jusqu'à l'implémentation",
-      "Animation des discussions sur l'organisation du travail design et développement à mesure que l'équipe grandit, incluant le processus de passation et les conventions communes",
+    body: [
+      "Je travaille à la fois en design et en développement front-end, en passant de Figma au code de production sur les mêmes projets clients. Développer ce que j'ai conçu change ma façon de concevoir la fois suivante, alors j'essaie de rester des deux côtés de cette ligne.",
+      "Jusqu'ici, j'ai livré des améliorations front-end sur un produit client en production, en corrigeant des défauts d'interaction et en modernisant une interface vieillissante, et je développe de nouvelles fonctionnalités B2B de révision des limites de crédit, des premières maquettes jusqu'à l'implémentation. Comme l'équipe grandit, j'aide aussi à définir la façon dont nous organisons le design et le développement, y compris le processus de passation et les conventions que nous partageons.",
     ],
   },
   {
-    position: 'UX Engineer',
     company: 'Keatext',
+    roles: ['UX Engineer'],
     startDate: 'mai 2021',
     endDate: 'mai 2026',
-    description: [
-      "Responsable du design produit et de la direction front-end d'une plateforme d'analyse par IA, assurant la liaison entre design et ingénierie sur tout le cycle de vie du produit",
-      "Conception et livraison de l'interface d'un produit d'analyse agentique, incluant un rapport généré par LLM avec des visualisations de données sur mesure et une interface conversationnelle pour interroger les résultats",
-      "Refonte de l'expérience principale pour l'IA conversationnelle, là où les conventions d'interface traditionnelles ne tenaient plus, en définissant les modèles d'interaction pour le streaming, l'incertitude et les actions initiées par l'agent",
-      "Transformation d'une interface fragmentée en système de composants réutilisables basé sur des design tokens, puis maintien en React et TypeScript de production, avec l'accessibilité et la fidélité des interactions comme exigences et non comme finition",
-      "Développement d'outils d'export et d'import de tokens via l'API Figma, avant que la plateforme ne prenne en charge les variables nativement, gardant design et code synchronisés à partir d'une source unique",
-      'Mise en place de flux de travail design-développement avec les product owners et les ingénieurs, réduisant les allers-retours de passation et rendant les décisions de design lisibles dans le code',
+    body: [
+      "Pendant cinq ans, j'ai été responsable du design produit et de la direction front-end d'une plateforme d'analyse par IA, entre le design et l'ingénierie sur tout le cycle de vie du produit. Ce que j'ai préféré, c'est l'interface d'un produit d'analyse agentique : un rapport généré par LLM avec des visualisations de données sur mesure, et une interface conversationnelle pour creuser les résultats. Les conventions d'interface traditionnelles tiennent mal en IA conversationnelle, alors une bonne partie du travail a consisté à trouver des modèles d'interaction pour le streaming, pour les réponses incertaines et pour les actions que l'agent entreprend de lui-même.",
+      "Le reste du poste relevait des systèmes. J'ai transformé une interface fragmentée en système de composants réutilisables basé sur des design tokens, puis je l'ai maintenu en React et TypeScript de production, avec l'accessibilité et la fidélité des interactions traitées comme des exigences plutôt que comme des finitions. Figma ne prenait pas encore en charge les variables, alors j'ai développé des outils d'export et d'import de tokens via son API pour que le design et le code travaillent à partir d'une seule source. J'ai aussi mis en place des flux de travail design-développement avec les product owners et les ingénieurs, ce qui a réduit les allers-retours de passation et rendu les décisions de design plus faciles à suivre dans le code.",
     ],
   },
   {
-    position: 'UX/UI Design Lead',
     company: 'Spartan Bioscience',
-    startDate: 'juin 2017',
-    endDate: 'mai 2021',
-    description: [
-      "Création d'un système de design à partir de zéro, composants, documentation et Storybook, pour des logiciels de dispositifs médicaux en environnement réglementé",
-      "Conception et réalisation de prototypes haute-fidélité et d'interfaces de production pour des logiciels de diagnostic et des produits de formation",
-      'Contribution à la documentation de design des dossiers réglementaires FDA 510(k) et livraison de fonctionnalités produit conformes à la HIPAA',
-      "Mise en œuvre et maintenance d'un portail d'assistance client et d'un site d'entreprise avec intégration CMS headless",
-      "Collaboration directe avec l'ingénierie, la gestion et la direction générale pour faire avancer les décisions de design",
-    ],
-  },
-  {
-    position: 'Marketing Coordinator',
-    company: 'Spartan Bioscience',
+    roles: ['UX/UI Design Lead', 'Marketing Coordinator'],
     startDate: 'avril 2015',
-    endDate: 'juin 2017',
-    description: [
-      "Participation aux initiatives de design UX et produit aux côtés de l'équipe principale",
-      "Gestion du site WordPress de l'entreprise et de l'infrastructure serveur",
+    endDate: 'mai 2021',
+    body: [
+      "J'ai passé six ans chez Spartan, en commençant du côté marketing avant de passer au design. Comme Marketing Coordinator, je travaillais sur le design UX et produit avec l'équipe principale, tout en m'occupant du site WordPress de l'entreprise et de son infrastructure serveur. J'ai pris la direction du design en 2017.",
+      "J'ai ensuite créé un système de design à partir de zéro pour des logiciels de dispositifs médicaux en environnement réglementé, avec les composants, la documentation et Storybook. J'ai conçu et réalisé des prototypes haute-fidélité et des interfaces de production pour des logiciels de diagnostic et des produits de formation. Le contexte réglementaire faisait que ma documentation de design alimentait les dossiers réglementaires FDA 510(k) et que tout ce que je livrais devait être conforme à la HIPAA. J'ai aussi développé et maintenu un portail d'assistance client et le site d'entreprise sur un CMS headless, en collaborant directement avec l'ingénierie, la gestion et la direction générale.",
     ],
   },
 ];
-
-export const skills = {
-  en: [
-    'Design Systems',
-    'Tokens & Component Architecture',
-    'Agentic and LLM Interface Design',
-    'Conversational UI',
-    'UX Design',
-    'Accessibility',
-    'Prototyping',
-    'React',
-    'Vue/Nuxt',
-    'TypeScript/JavaScript',
-    'CSS',
-    'Figma',
-    'Figma API',
-    'Storybook',
-    'AI-assisted Workflows',
-  ],
-  fr: [
-    'Systèmes de design',
-    'Tokens et architecture de composants',
-    "Conception d'interfaces agentiques et LLM",
-    'UI conversationnelle',
-    'Design UX',
-    'Accessibilité',
-    'Prototypage',
-    'React',
-    'Vue/Nuxt',
-    'TypeScript/JavaScript',
-    'CSS',
-    'Figma',
-    'API Figma',
-    'Storybook',
-    'Flux de travail assistés par IA',
-  ],
-};
-
-export const languages = {
-  en: ['English (native)', 'French'],
-  fr: ['Anglais (natif)', 'Français'],
-};
 
 export default {
   en,

--- a/app/assets/data/work-experience.ts
+++ b/app/assets/data/work-experience.ts
@@ -13,16 +13,28 @@ interface WorkExperienceItem {
 
 const en: WorkExperienceItem[] = [
   {
+    position: 'Design Engineer',
+    company: 'Volume7',
+    startDate: 'July 2026',
+    description: [
+      'Work across design and frontend development, moving between Figma and production code on the same client projects',
+      'Shipped frontend improvements to a live client product, resolving interaction defects and modernizing legacy UI',
+      'Building new B2B credit limit review features, carrying flows from design through implementation',
+      'Led discussions on how the team organizes design and development work as the org scales, covering handoff process and shared conventions',
+    ],
+  },
+  {
     position: 'UX Engineer',
     company: 'Keatext',
     startDate: 'May 2021',
     endDate: 'May 2026',
     description: [
-      'Owned product design and front-end direction, serving as the bridge between design and engineering',
-      "Redesigned the core user experience for conversational AI that traditional UI patterns didn't address",
-      'Partnered with product owners and engineers to shape roadmap and strategy, establishing design-to-development workflows that cut handoff loops',
-      'Designed, built, and maintained production React + TypeScript components with  interaction fidelity and accessibility at their core',
-      'Converted fragmented UI into a reusable component system built on design tokens',
+      'Owned product design and frontend direction for an AI analytics platform, serving as the bridge between design and engineering across the full product lifecycle',
+      'Designed and shipped the interface for an agentic analysis product, including an LLM-driven report with custom data visualization and a conversational interface for interrogating results',
+      'Redesigned the core experience for conversational AI where traditional UI patterns broke down, defining interaction models for streaming, uncertainty, and agent-initiated actions',
+      'Converted a fragmented UI into a reusable component system built on design tokens, then maintained it as production React and TypeScript with accessibility and interaction fidelity as requirements, not polish',
+      'Built token export and import tooling against the Figma API before the platform supported variables natively, keeping design and code in sync from a single source',
+      'Established design-to-development workflows with product owners and engineers that cut handoff loops and made design decisions legible in code',
     ],
   },
   {
@@ -31,11 +43,11 @@ const en: WorkExperienceItem[] = [
     startDate: 'June 2017',
     endDate: 'May 2021',
     description: [
-      'Designed and built interactive, high-fidelity prototypes and production interfaces for medical software and training products',
-      'Built a design system from the ground up with full documentation',
-      'Developed and maintained a web-based customer support portal and corporate site with headless CMS integration',
-      'Collaborated with cross-functional teams spanning engineering, management, and executive leadership',
-      'Synthesized multi-channel feedback into iterative design revisions, maintaining a single source of truth',
+      'Built a design system from scratch, components, documentation, and Storybook, for medical device software in a regulated environment',
+      'Designed and built high-fidelity prototypes and production interfaces for diagnostic software and training products',
+      'Contributed design documentation to FDA 510(k) submissions and shipped HIPAA-compliant product surfaces',
+      'Developed and maintained a customer support portal and corporate site with headless CMS integration',
+      'Worked directly with engineering, management, and executive leadership to move design decisions forward',
     ],
   },
   {
@@ -46,7 +58,6 @@ const en: WorkExperienceItem[] = [
     description: [
       'Contributed to UX and product design alongside the core team',
       'Managed the company WordPress site and server infrastructure',
-      'Designed marketing collateral and training documentation',
     ],
   },
 ];
@@ -54,72 +65,94 @@ const en: WorkExperienceItem[] = [
 const fr: WorkExperienceItem[] = [
   {
     position: 'Design Engineer',
+    company: 'Volume7',
+    startDate: 'juillet 2026',
+    description: [
+      'Travail à la fois en design et en développement front-end, en passant de Figma au code de production sur les mêmes projets clients',
+      "Livraison d'améliorations front-end sur un produit client en production, en corrigeant des défauts d'interaction et en modernisant une interface existante",
+      "Développement de nouvelles fonctionnalités B2B de révision des limites de crédit, du design jusqu'à l'implémentation",
+      "Animation des discussions sur l'organisation du travail design et développement à mesure que l'équipe grandit, incluant le processus de passation et les conventions communes",
+    ],
+  },
+  {
+    position: 'UX Engineer',
     company: 'Keatext',
     startDate: 'mai 2021',
     endDate: 'mai 2026',
     description: [
-      'Responsable du design produit et de la direction front-end, assurant la liaison entre design et ingénierie',
-      "Refondu l'expérience utilisateur principale pour l'IA conversationnelle, que les patterns d'interface traditionnels ne prenaient pas en charge",
-      'Collaboré avec les product owners et les ingénieurs pour façonner la feuille de route et la stratégie, en établissant des workflows design-développement efficaces',
-      "Conçu, développé et maintenu des composants React + TypeScript de production, avec la fidélité des interactions et l'accessibilité au cœur",
-      'Transformé une interface fragmentée en système de composants réutilisables basé sur des design tokens',
+      "Responsable du design produit et de la direction front-end d'une plateforme d'analyse par IA, assurant la liaison entre design et ingénierie sur tout le cycle de vie du produit",
+      "Conception et livraison de l'interface d'un produit d'analyse agentique, incluant un rapport généré par LLM avec des visualisations de données sur mesure et une interface conversationnelle pour interroger les résultats",
+      "Refonte de l'expérience principale pour l'IA conversationnelle, là où les conventions d'interface traditionnelles ne tenaient plus, en définissant les modèles d'interaction pour le streaming, l'incertitude et les actions initiées par l'agent",
+      "Transformation d'une interface fragmentée en système de composants réutilisables basé sur des design tokens, puis maintien en React et TypeScript de production, avec l'accessibilité et la fidélité des interactions comme exigences et non comme finition",
+      "Développement d'outils d'export et d'import de tokens via l'API Figma, avant que la plateforme ne prenne en charge les variables nativement, gardant design et code synchronisés à partir d'une source unique",
+      'Mise en place de flux de travail design-développement avec les product owners et les ingénieurs, réduisant les allers-retours de passation et rendant les décisions de design lisibles dans le code',
     ],
   },
   {
-    position: 'Concepteur UX/UI principal',
+    position: 'UX/UI Design Lead',
     company: 'Spartan Bioscience',
     startDate: 'juin 2017',
     endDate: 'mai 2021',
     description: [
-      'Création de prototypes interactifs et hautes-fidélités ainsi que des interfaces de production pour des logiciels médicaux et leurs produits de formation',
-      "Développement d'un système de design de zéro avec une documentation complète",
-      "Mise en œuvre et maintenance d'un portail d'assistance client et d'un site corporatif avec intégration CMS headless",
-      'Collaboration avec des équipes transversales regroupant ingénierie, gestion et direction générale',
-      'Synthétisation de retours multicanaux en révisions itératives, en maintenant une source de vérité unique',
+      "Création d'un système de design à partir de zéro, composants, documentation et Storybook, pour des logiciels de dispositifs médicaux en environnement réglementé",
+      "Conception et réalisation de prototypes haute-fidélité et d'interfaces de production pour des logiciels de diagnostic et des produits de formation",
+      'Contribution à la documentation de design des dossiers réglementaires FDA 510(k) et livraison de fonctionnalités produit conformes à la HIPAA',
+      "Mise en œuvre et maintenance d'un portail d'assistance client et d'un site d'entreprise avec intégration CMS headless",
+      "Collaboration directe avec l'ingénierie, la gestion et la direction générale pour faire avancer les décisions de design",
     ],
   },
   {
-    position: 'Coordinateur marketing',
+    position: 'Marketing Coordinator',
     company: 'Spartan Bioscience',
     startDate: 'avril 2015',
     endDate: 'juin 2017',
     description: [
       "Participation aux initiatives de design UX et produit aux côtés de l'équipe principale",
-      "Gestion du site WordPress de l'entreprise et l'infrastructure serveur",
-      'Production de supports marketing et de documentation de formation',
+      "Gestion du site WordPress de l'entreprise et de l'infrastructure serveur",
     ],
   },
 ];
 
 export const skills = {
   en: [
+    'Design Systems',
+    'Tokens & Component Architecture',
     'Agentic and LLM Interface Design',
     'Conversational UI',
-    'Design Systems',
     'UX Design',
     'Accessibility',
+    'Prototyping',
     'React',
-    'Figma',
+    'Vue/Nuxt',
     'TypeScript/JavaScript',
     'CSS',
-    'Prototyping',
-    'English (native)',
-    'French',
+    'Figma',
+    'Figma API',
+    'Storybook',
+    'AI-assisted Workflows',
   ],
   fr: [
-    "Conception d'interfaces agentiques",
-    'UI conversationnelle',
     'Systèmes de design',
+    'Tokens et architecture de composants',
+    "Conception d'interfaces agentiques et LLM",
+    'UI conversationnelle',
     'Design UX',
     'Accessibilité',
+    'Prototypage',
     'React',
-    'Figma',
+    'Vue/Nuxt',
     'TypeScript/JavaScript',
     'CSS',
-    'Prototypage',
-    'Anglais (natif)',
-    'Français',
+    'Figma',
+    'API Figma',
+    'Storybook',
+    'Flux de travail assistés par IA',
   ],
+};
+
+export const languages = {
+  en: ['English (native)', 'French'],
+  fr: ['Anglais (natif)', 'Français'],
 };
 
 export default {

--- a/app/components/WorkExperienceItem.vue
+++ b/app/components/WorkExperienceItem.vue
@@ -1,121 +1,93 @@
+<script setup lang="ts">
+import { computed, useI18n } from '#imports';
+
+const props = defineProps<{
+  company: string;
+  roles: string[];
+  startDate: string;
+  endDate?: string;
+  body: string[];
+}>();
+
+const { t } = useI18n();
+
+const dateRange = computed(() =>
+  props.endDate
+    ? `${props.startDate} ${t('about.toDate')} ${props.endDate}`
+    : `${props.startDate} ${t('about.toPresentDate')}`,
+);
+</script>
+
 <template>
   <article class="work-experience-item">
-    <div class="work-experience-item__date">
-      <div class="work-experience-item__date-start">
-        {{ startDate }}
-      </div>
-
-      <div>
-        &nbsp;{{
-          endDate
-            ? `${$t('about.toDate')} ${endDate}`
-            : $t('about.toPresentDate')
-        }}
-      </div>
-    </div>
-
-    <div class="work-experience-item__heading">
-      <h1 class="heading-2 title">
-        {{ position }}
-      </h1>
-      <div class="subtitle">
+    <header class="work-experience-item__header">
+      <h3 class="work-experience-item__company heading-2 title">
         {{ company }}
-      </div>
-    </div>
+      </h3>
 
-    <div class="work-experience-item__description">
-      <ul class="work-experience-item__description-list">
-        <li
-          v-for="item in description"
-          :key="item"
-        >
-          {{ item }}
-        </li>
-      </ul>
+      <p class="work-experience-item__meta">
+        <span class="work-experience-item__roles">
+          {{ roles.join(' · ') }}
+        </span>
+
+        <span class="work-experience-item__date">
+          {{ dateRange }}
+        </span>
+      </p>
+    </header>
+
+    <div class="work-experience-item__body">
+      <p
+        v-for="paragraph in body"
+        :key="paragraph"
+      >
+        {{ paragraph }}
+      </p>
     </div>
   </article>
 </template>
 
-<script>
-export default {
-  name: 'WorkExperienceItem',
-
-  props: {
-    startDate: {
-      type: String,
-      required: true,
-    },
-    endDate: {
-      type: String,
-      default: '',
-    },
-    position: {
-      type: String,
-      required: true,
-    },
-    company: {
-      type: String,
-      required: true,
-    },
-    description: {
-      type: Array,
-      required: true,
-    },
-  },
-};
-</script>
-
 <style lang="scss">
-@use 'sass:math';
 @use '~/assets/styles/utils/breakpoints' as bp;
 
 .work-experience-item {
-  display: grid;
-  gap: 1rem;
-  grid-template:
-    'date heading'
-    '. description'
-    / (math.div(1, 6) * 100%) auto;
-
   & ~ & {
-    margin-top: 3rem;
+    border-block-start: 1px solid var(--color-border);
+    margin-block-start: var(--space-12);
+    padding-block-start: var(--space-12);
+  }
+
+  &__header {
+    margin-block-end: var(--space-6);
+  }
+
+  &__meta {
+    color: var(--color-text-muted);
+    display: flex;
+    flex-direction: column;
+    font-size: var(--text-sm);
+    gap: var(--space-1);
+    margin-block: var(--space-2) 0;
+
+    @container (min-width: #{bp.$sm}) {
+      align-items: baseline;
+      flex-direction: row;
+      gap: var(--space-4);
+      justify-content: space-between;
+    }
   }
 
   &__date {
-    align-self: end;
-    color: var(--color-text-muted);
-    font-size: var(--text-sm);
-    grid-area: date;
-    line-height: 1.8;
-    text-align: right;
+    white-space: nowrap;
   }
 
-  &__heading {
-    grid-area: heading;
-
-    .subtitle {
-      color: var(--color-text-muted);
+  &__body {
+    p {
+      margin-block: 0;
     }
-  }
 
-  &__description {
-    grid-area: description;
-
-    &-list {
-      margin: 0;
-      padding-left: 1.25rem;
-    }
-  }
-
-  @container (max-width: #{bp.$sm - 1}) {
-    column-gap: 0;
-    grid-template:
-      'heading date'
-      'description description' / 1fr auto;
-
-    &__date {
-      display: inline-flex;
-      justify-content: flex-end;
+    p + p {
+      margin-block-start: var(--space-4);
     }
   }
 }

--- a/app/pages/about.vue
+++ b/app/pages/about.vue
@@ -1,8 +1,19 @@
 <script setup lang="ts">
-import { definePageMeta, useI18n, useLocalePath } from '#imports';
+import { computed, definePageMeta, useI18n, useLocalePath } from '#imports';
+import workExperience, {
+  skills,
+  languages,
+} from '~/assets/data/work-experience';
+import WorkExperienceItem from '~/components/WorkExperienceItem.vue';
 
 const localePath = useLocalePath();
 const { locale } = useI18n();
+
+const skillChips = computed(() => {
+  const key = locale.value as keyof typeof skills;
+
+  return [...skills[key], ...languages[key]];
+});
 
 definePageMeta({
   i18n: {
@@ -63,7 +74,7 @@ definePageMeta({
             v-for="item in workExperience[
               locale as keyof typeof workExperience
             ]"
-            :key="item.position"
+            :key="`${item.company}-${item.position}`"
             v-bind="item"
           />
         </div>
@@ -77,8 +88,8 @@ definePageMeta({
 
           <ul class="about-skills">
             <li
-              v-for="(skill, index) in skills[locale]"
-              :key="index"
+              v-for="skill in skillChips"
+              :key="skill"
             >
               <BaseChip>{{ skill }}</BaseChip>
             </li>
@@ -104,23 +115,6 @@ definePageMeta({
     </div>
   </div>
 </template>
-
-<script lang="ts">
-import workExperience, { skills } from '~/assets/data/work-experience';
-import WorkExperienceItem from '~/components/WorkExperienceItem.vue';
-
-export default {
-  components: {
-    WorkExperienceItem,
-  },
-
-  data() {
-    return {
-      workExperience,
-    };
-  },
-};
-</script>
 
 <style lang="scss">
 @use 'sass:math';

--- a/app/pages/about.vue
+++ b/app/pages/about.vue
@@ -1,19 +1,9 @@
 <script setup lang="ts">
-import { computed, definePageMeta, useI18n, useLocalePath } from '#imports';
-import workExperience, {
-  skills,
-  languages,
-} from '~/assets/data/work-experience';
+import { definePageMeta, useI18n } from '#imports';
+import workExperience from '~/assets/data/work-experience';
 import WorkExperienceItem from '~/components/WorkExperienceItem.vue';
 
-const localePath = useLocalePath();
 const { locale } = useI18n();
-
-const skillChips = computed(() => {
-  const key = locale.value as keyof typeof skills;
-
-  return [...skills[key], ...languages[key]];
-});
 
 definePageMeta({
   i18n: {
@@ -33,92 +23,71 @@ definePageMeta({
       </Title>
     </Head>
 
-    <section class="about-intro">
-      <h1 class="heading-1">
-        {{ $t('about.mainHeading') }}
-      </h1>
+    <main class="about-layout">
+      <section class="about-intro">
+        <h1 class="heading-1">
+          {{ $t('about.mainHeading') }}
+        </h1>
 
-      <p>
-        {{ $t('about.blurb') }}
-      </p>
+        <p>
+          {{ $t('about.blurb') }}
+        </p>
 
-      <div class="about-intro__links">
-        <NuxtLink
-          :to="localePath('/contact/')"
-          class="link link--arrow"
-        >
-          {{ $t('common.contact') }}
-        </NuxtLink>
-
-        <a
-          class="link link--arrow"
-          :href="`/docs/${locale === 'en' ? 'alex-collier-resume' : 'cv-alex-collier'}.pdf`"
-          target="_blank"
-          rel="noopener nofollow"
-        >
-          {{ $t('about.resumeDownload') }}
-        </a>
-      </div>
-    </section>
-
-    <div class="two-column about-content">
-      <main class="work-experience two-column__wide-col">
-        <div class="work-experience__heading">
-          <h2 class="heading-1">
-            {{ $t('about.experienceHeading') }}
-          </h2>
+        <div class="about-intro__links">
+          <a
+            class="link link--arrow"
+            :href="`/docs/${locale === 'en' ? 'alex-collier-resume' : 'cv-alex-collier'}.pdf`"
+            target="_blank"
+            rel="noopener nofollow"
+          >
+            {{ $t('about.resumeDownload') }}
+          </a>
         </div>
+      </section>
 
-        <div class="work-experience__list">
-          <WorkExperienceItem
-            v-for="item in workExperience[
-              locale as keyof typeof workExperience
-            ]"
-            :key="`${item.company}-${item.position}`"
-            v-bind="item"
-          />
-        </div>
-      </main>
+      <section class="about-section">
+        <h2 class="heading-1">
+          {{ $t('about.experienceHeading') }}
+        </h2>
 
-      <aside class="two-column__narrow-col sidebar">
-        <section class="sidebar__section">
-          <h2 class="heading-1">
-            {{ $t('about.skillsHeading') }}
-          </h2>
+        <WorkExperienceItem
+          v-for="item in workExperience[locale as keyof typeof workExperience]"
+          :key="item.company"
+          v-bind="item"
+        />
+      </section>
 
-          <ul class="about-skills">
-            <li
-              v-for="skill in skillChips"
-              :key="skill"
-            >
-              <BaseChip>{{ skill }}</BaseChip>
-            </li>
-          </ul>
+      <section class="about-section">
+        <h2 class="heading-1">
+          {{ $t('about.educationHeading') }}
+        </h2>
 
-          <h2 class="heading-1">
-            {{ $t('about.educationHeading') }}
-          </h2>
+        <h3 class="heading-2 title">Carleton University</h3>
 
-          <h3 class="heading-2 title">Carleton University</h3>
+        <p class="subtitle">
+          {{ $t('about.bcomm') }}
+        </p>
+      </section>
 
-          <p class="subtitle">
-            {{ $t('about.bcomm') }}
-          </p>
+      <section class="about-section">
+        <h2 class="heading-1">
+          {{ $t('about.linksHeading') }}
+        </h2>
 
-          <h2 class="heading-1">
-            {{ $t('about.linksHeading') }}
-          </h2>
-
-          <SocialLinks />
-        </section>
-      </aside>
-    </div>
+        <SocialLinks />
+      </section>
+    </main>
   </div>
 </template>
 
 <style lang="scss">
-@use 'sass:math';
 @use '~/assets/styles/utils/breakpoints' as bp;
+
+.about-layout {
+  /* Matches the reading column on the portfolio pages: 8 of 12 cols at bp.$xl */
+  margin-inline: auto;
+  max-width: calc(#{bp.$xl} * 2 / 3);
+}
 
 .about-intro {
   font-size: var(--text-lg);
@@ -129,52 +98,14 @@ definePageMeta({
     flex-wrap: wrap;
     gap: var(--space-4);
     justify-content: flex-start;
-
-    @include bp.above('md') {
-      gap: var(--space-4) var(--space-24);
-    }
   }
 
   @include bp.above('sm') {
     font-size: var(--text-xl);
   }
-
-  @include bp.above('md') {
-    font-size: var(--text-2xl);
-    margin-inline: calc(math.div(1, 9) * 100% + 1rem);
-    max-width: math.div(3, 4) * 100%;
-  }
 }
 
-.about-content {
-  margin-block-start: var(--space-12);
-
-  @include bp.above('md') {
-    margin-block-start: 5rem;
-  }
-}
-
-.about-skills {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-2);
-  list-style: none;
-  padding-left: 0;
-}
-
-.work-experience {
-  &__heading {
-    margin-bottom: var(--heading-1-bottom-margin);
-
-    .heading-1 {
-      margin-bottom: 0;
-    }
-  }
-
-  @include bp.above('md') {
-    &__heading {
-      margin-left: calc((math.div(1, 6) * 100%) + 1rem);
-    }
-  }
+.about-section {
+  margin-block-start: var(--space-16);
 }
 </style>

--- a/i18n/locales/en/index.ts
+++ b/i18n/locales/en/index.ts
@@ -24,7 +24,7 @@ export default {
     metaTitle: 'About',
     mainHeading: 'About',
     blurb:
-      'I thrive in high-complexity environments, with nearly 10 years of experience including designing for medical and scientific testing, and shipping agentic experiences.',
+      'I work at the seam between design and frontend engineering. A decade shipping production interfaces, design systems, and AI product experiences, from token architecture and component libraries to conversational and agentic LLM interfaces.',
     resumeDownload: 'Download my resume',
     experienceHeading: 'Experience',
     educationHeading: 'Education',

--- a/i18n/locales/fr/index.ts
+++ b/i18n/locales/fr/index.ts
@@ -32,9 +32,9 @@ export default <LangSchema>{
     metaTitle: 'À propos',
     mainHeading: 'À propos',
     blurb:
-      "À l'aise dans les environnements complexes, j'ai près de 10 ans d'expérience en conception, notamment pour les tests médicaux et scientifiques, et pour des expériences agentiques.",
+      "Je travaille à la jonction du design et du développement front-end. Une décennie à livrer des interfaces de production, des systèmes de design et des expériences produit en IA, de l'architecture de tokens aux bibliothèques de composants jusqu'aux interfaces LLM conversationnelles et agentiques.",
     resumeDownload: 'Télécharger mon CV',
-    experienceHeading: 'Expérience professionelle',
+    experienceHeading: 'Expérience professionnelle',
     educationHeading: 'Éducation',
     bcomm: 'Baccalauréat en commerce, commerce international et marketing',
     toPresentDate: 'au présent',


### PR DESCRIPTION
Brings the about page up to date and moves it away from repeating the resume.

## Content

- Adds the **Volume7 / Design Engineer** role and rewrites the Keatext and Spartan entries from the current resume.
- Replaces the bullet lists with **one to two paragraphs per org**. Spartan's two roles merge into a single entry, with the move from marketing into design told in the prose rather than split across two stubs.
- Rewrites the intro blurb in both locales.
- Prose avoids em dashes and the sentence shapes that read as machine-written.

## Data shape

`work-experience.ts` is now organised around orgs rather than roles: `{ company, roles[], startDate, endDate?, body[] }`, where `body` is one string per paragraph and `roles` carries a progression.

This intentionally **diverges from `acollier-content`**, which keeps bullets for the PDF and the assistant prompt. Prose suits the page; bullets suit the resume.

## Layout

- Single column, centred, capped at the same reading measure as the portfolio pages (8 of 12 columns at `bp.$xl`).
- Drops the two column layout, the skills and languages chips, and the contact link. Education and links move into the main flow.
- `WorkExperienceItem` leads with the company, with roles and dates on a meta line beneath, and separates entries with a hairline rule. Converted to `<script setup>`, since the props changed wholesale.
- Fixes a heading order bug: role headings were `h1` styled as `heading-2` beneath an existing `h1`. They are now `h3` under the section `h2`.
- Corrects the misspelled French experience heading (`professionelle`).

## French copy

Same corrections as alexkcollier/acollier-content#2: titles stay in English (`ingénieur` is a reserved title in Quebec), plus grammar and calque fixes.

## Verification

ESLint, stylelint, `nuxi typecheck`, and a full `nuxi generate` all pass. Rendered `/about/` and `/fr/a-propos/` were inspected to confirm both locales, the heading order, and that no em dashes survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)